### PR TITLE
feat(speed): Reduce redundant LLM calls in case of re-runs

### DIFF
--- a/boilerplate_x/constants.py
+++ b/boilerplate_x/constants.py
@@ -34,8 +34,3 @@ ONLY create file content for the file name specified below. You must be clear an
 
 File name: {file_name}
 File content:"""
-
-GIT_DEFAULT_COMMIT_MESSAGE = "Initial commit"
-GIT_DEFAULT_REMOTE = "origin"
-GIT_USER = "boilerplate-x"
-GIT_EMAIL = "boilerplate-x@noreply.github.com"

--- a/boilerplate_x/github.py
+++ b/boilerplate_x/github.py
@@ -3,14 +3,10 @@ import logging
 from git import Repo
 from github import Github
 
-from .constants import (
-    GIT_DEFAULT_COMMIT_MESSAGE,
-    GIT_DEFAULT_REMOTE,
-    GIT_EMAIL,
-    GIT_USER,
-)
+from .schemas import GithubRepoCreatorSchema
 
 logger = logging.getLogger(__name__)
+schema = GithubRepoCreatorSchema()
 
 
 class GithubRepoCreator:
@@ -22,7 +18,7 @@ class GithubRepoCreator:
         repo_name: str,
         private: bool,
         target_folder: str,
-        commit_message: str = GIT_DEFAULT_COMMIT_MESSAGE,
+        commit_message: str = schema.default_commit_message,
     ):
         self.token = token
 
@@ -41,8 +37,8 @@ class GithubRepoCreator:
         # initialize the local repository
         default_branch_name = gh_repo.default_branch
         git_repo = Repo.init(self.target_folder, initial_branch=default_branch_name)
-        git_repo.config_writer().set_value("user", "name", GIT_USER).release()
-        git_repo.config_writer().set_value("user", "email", GIT_EMAIL).release()
+        git_repo.config_writer().set_value("user", "name", schema.user).release()
+        git_repo.config_writer().set_value("user", "email", schema.email).release()
 
         # commit files
         git_repo.git.add(A=True)
@@ -50,10 +46,10 @@ class GithubRepoCreator:
 
         # push changes
         git_repo.create_remote(
-            GIT_DEFAULT_REMOTE,
+            schema.default_remote,
             gh_repo.clone_url.replace("https://", f"https://{self.token}@"),
         )
-        git_repo.git.push(GIT_DEFAULT_REMOTE, default_branch_name)
+        git_repo.git.push(schema.default_remote, default_branch_name)
         logger.info("GitHub repository setup complete.")
 
         return gh_repo.html_url

--- a/boilerplate_x/schemas.py
+++ b/boilerplate_x/schemas.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Field
+
+
+class ChatOpenAISchema(BaseModel):
+    temperature: float = 0.0
+    request_timeout: int = 300
+
+
+class ProjectStructureLLMSchema(ChatOpenAISchema):
+    max_tokens: int = 256
+
+
+class ProjectFileLLMSchema(ChatOpenAISchema):
+    max_tokens: int = 2048
+
+
+class ProjectGeneratorSchema(BaseModel):
+    project_structure_llm: ProjectStructureLLMSchema = Field(
+        default_factory=ProjectStructureLLMSchema
+    )
+    project_file_llm: ProjectFileLLMSchema = Field(default_factory=ProjectFileLLMSchema)
+    project_structure_file_name: str = ".boilerplate_x"
+
+
+class GithubRepoCreatorSchema(BaseModel):
+    default_commit_message: str = "Initial commit"
+    default_remote: str = "origin"
+    user: str = "boilerplate-x"
+    email: str = "boilerplate-x@noreply.github.com"


### PR DESCRIPTION
## Description

Closes #6 

This PR adds a new feature to generate a `.boilerplate_x` file to cache results from `project_structure_chain`. In case of re-runs if `.boilerplate_x` is found, `project_structure_chain` call is skipped. All files generated in a previous run are skipped to avoid redundant LLM calls.

### Changelog

- ✨ added new schemas using `pydantic`
- ⚡ increased timeout to 300 seconds (related #5)
- ♻️ refactor classes to use schemas instead of constants